### PR TITLE
links in mix.exs is now a map. Bump and tested with Elixir 1.0.0 too

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Dexts.Mixfile do
   def project do
     [ app: :dexts,
       version: "0.2.0",
-      elixir: "~> 0.14.3",
+      elixir: "~> 1.0.0",
       package: package,
       description: "dets wrapper for Elixir" ]
   end
@@ -12,6 +12,6 @@ defmodule Dexts.Mixfile do
   defp package do
     [ contributors: ["meh"],
       licenses: ["WTFPL"],
-      links: [ { "GitHub", "https://github.com/meh/dexts" } ] ]
+      links: %{ "GitHub" => "https://github.com/meh/dexts" }
   end
 end


### PR DESCRIPTION
links in mix.exs is now a map. Bump and tested with Elixir 1.0.0 too
